### PR TITLE
Temporary disable WalletConnect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "universalprofile-sample-web-app",
+  "name": "universalprofile-test-dapp",
   "version": "0.1.54",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "universalprofile-sample-web-app",
+      "name": "universalprofile-test-dapp",
       "version": "0.1.54",
       "dependencies": {
         "@erc725/erc725.js": "0.14.4",
@@ -53,6 +53,9 @@
         "vite": "^3.0.7",
         "vue-loader": "17.0.0",
         "vue-tsc": "^0.40.1"
+      },
+      "engines": {
+        "node": "16.16.0"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/src/components/Connect.vue
+++ b/src/components/Connect.vue
@@ -4,26 +4,26 @@ import { ref, onMounted, onUnmounted } from 'vue'
 import { EthereumProviderError } from 'eth-rpc-errors'
 import useDropdown from '@/compositions/useDropdown'
 import useWeb3 from '@/compositions/useWeb3'
-import useWalletConnect, {
-  WALLET_CONNECT_VERSION as walletConnectVersion,
-} from '@/compositions/useWalletConnect'
+// import useWalletConnect, {
+//   WALLET_CONNECT_VERSION as walletConnectVersion,
+// } from '@/compositions/useWalletConnect'
 import { UP_CONNECTED_ADDRESS } from '@/helpers/config'
 import { sliceAddress } from '@/utils/sliceAddress'
 
 const { setupWeb3, accounts, requestAccounts } = useWeb3()
-const { resetProvider, setupProvider, enableProvider, getProvider } =
-  useWalletConnect()
+// const { resetProvider, setupProvider, enableProvider, getProvider } =
+//   useWalletConnect()
 const { setDisconnected, setConnected } = useState()
 const { close, toggle } = useDropdown()
 const dropdown = ref()
 const browserExtensionConnected = localStorage.getItem(UP_CONNECTED_ADDRESS)
 const hasExtension = !!window.ethereum
 
-const connectWalletConnect = async () => {
-  close(dropdown.value)
-  await setupProvider()
-  await enableProvider()
-}
+// const connectWalletConnect = async () => {
+//   close(dropdown.value)
+//   await setupProvider()
+//   await enableProvider()
+// }
 
 const connectExtension = async () => {
   try {
@@ -51,7 +51,7 @@ const connectExtension = async () => {
 
 const disconnect = async () => {
   if (getState('channel') == 'walletConnect') {
-    await resetProvider()
+    // await resetProvider()
   } else {
     localStorage.removeItem(UP_CONNECTED_ADDRESS)
   }
@@ -97,13 +97,13 @@ const removeEventListeners = () => {
 }
 
 onMounted(async () => {
-  await setupProvider()
+  // await setupProvider()
 
-  if (getProvider().wc.connected) {
-    await enableProvider()
-  } else if (browserExtensionConnected) {
-    await connectExtension()
-  }
+  // if (getProvider().wc.connected) {
+  //   await enableProvider()
+  // } else if (browserExtensionConnected) {
+  await connectExtension()
+  // }
 
   addEventListeners()
 })
@@ -178,11 +178,18 @@ onUnmounted(() => {
         <button
           class="dropdown-item has-text-weight-bold button is-text"
           data-testid="connect-wc"
+        >
+          <div class="logo wallet-connect" />
+          [Disabled] Wallet Connect
+        </button>
+        <!-- <button
+          class="dropdown-item has-text-weight-bold button is-text"
+          data-testid="connect-wc"
           @click="connectWalletConnect"
         >
           <div class="logo wallet-connect" />
           Wallet Connect {{ walletConnectVersion }}
-        </button>
+        </button> -->
       </div>
     </div>
   </div>

--- a/src/components/endpoints/Accounts.vue
+++ b/src/components/endpoints/Accounts.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import Notifications from '@/components/Notification.vue'
 import useNotifications from '@/compositions/useNotifications'
-import useWalletConnect, {
-  WALLET_CONNECT_VERSION as walletConnectVersion,
-} from '@/compositions/useWalletConnect'
+// import useWalletConnect, {
+//   WALLET_CONNECT_VERSION as walletConnectVersion,
+// } from '@/compositions/useWalletConnect'
 import { getState, useState } from '@/stores'
 import useWeb3 from '@/compositions/useWeb3'
 import { UP_CONNECTED_ADDRESS } from '@/helpers/config'
@@ -15,7 +15,7 @@ const { notification, clearNotification, hasNotification, setNotification } =
   useNotifications()
 const { setDisconnected, setConnected } = useState()
 const { setupWeb3, requestAccounts } = useWeb3()
-const { resetProvider, enableProvider, setupProvider } = useWalletConnect()
+// const { resetProvider, enableProvider, setupProvider } = useWalletConnect()
 const hasExtension = !!window.ethereum
 
 const hexChainId = computed(() => {
@@ -35,24 +35,24 @@ const connectExtension = async () => {
   }
 }
 
-const connectWalletconnect = async () => {
-  clearNotification()
+// const connectWalletconnect = async () => {
+//   clearNotification()
 
-  try {
-    await setupProvider()
-    await enableProvider()
-    setConnected(getState('address'), 'walletConnect')
-    setNotification(`Connected to address: ${getState('address')}`, 'info')
-  } catch (error) {
-    setNotification((error as unknown as Error).message, 'danger')
-  }
-}
+//   try {
+//     await setupProvider()
+//     await enableProvider()
+//     setConnected(getState('address'), 'walletConnect')
+//     setNotification(`Connected to address: ${getState('address')}`, 'info')
+//   } catch (error) {
+//     setNotification((error as unknown as Error).message, 'danger')
+//   }
+// }
 
 const disconnect = async () => {
   clearNotification()
 
   if (getState('channel') == 'walletConnect') {
-    await resetProvider()
+    // await resetProvider()
   } else {
     localStorage.removeItem(UP_CONNECTED_ADDRESS)
   }
@@ -88,13 +88,20 @@ const disconnect = async () => {
         </span>
       </div>
       <div class="field">
-        <button
+        <!-- <button
           class="button is-primary is-rounded mb-3"
           :disabled="getState('address') ? true : undefined"
           data-testid="connect-wc"
           @click="connectWalletconnect"
         >
           Wallet Connect {{ walletConnectVersion }}
+        </button> -->
+        <button
+          class="button is-primary is-rounded mb-3"
+          :disabled="true"
+          data-testid="connect-wc"
+        >
+          [Disabled] Wallet Connect
         </button>
         <span
           v-if="

--- a/src/compositions/useWalletConnect.ts
+++ b/src/compositions/useWalletConnect.ts
@@ -1,70 +1,70 @@
-import WalletConnectProvider from '@walletconnect/web3-provider'
-import { setState, useState, getState } from '@/stores'
-import useWeb3 from '@/compositions/useWeb3'
-import { provider as Provider } from 'web3-core'
-import { DEFAULT_NETWORK_CONFIG } from '@/helpers/config'
+// import WalletConnectProvider from '@walletconnect/web3-provider'
+// import { setState, useState, getState } from '@/stores'
+// import useWeb3 from '@/compositions/useWeb3'
+// import { provider as Provider } from 'web3-core'
+// import { DEFAULT_NETWORK_CONFIG } from '@/helpers/config'
 
-let provider: WalletConnectProvider
-export const WALLET_CONNECT_VERSION = '1.0'
+// let provider: WalletConnectProvider
+// export const WALLET_CONNECT_VERSION = '1.0'
 
-const setupProvider = async (): Promise<void> => {
-  const { setupWeb3 } = useWeb3()
+// const setupProvider = async (): Promise<void> => {
+//   const { setupWeb3 } = useWeb3()
 
-  provider = new WalletConnectProvider({
-    rpc: {
-      22: DEFAULT_NETWORK_CONFIG.rpc.url,
-    },
-    bridge: 'https://safe-walletconnect.gnosis.io',
-    chainId: 22,
-  })
+//   provider = new WalletConnectProvider({
+//     rpc: {
+//       22: DEFAULT_NETWORK_CONFIG.rpc.url,
+//     },
+//     bridge: 'https://safe-walletconnect.gnosis.io',
+//     chainId: 22,
+//   })
 
-  provider.on('connect', (error: any) => {
-    if (error) {
-      throw error
-    }
+//   provider.on('connect', (error: any) => {
+//     if (error) {
+//       throw error
+//     }
 
-    setState('isConnected', true)
-    setupWeb3(provider as unknown as Provider)
-  })
+//     setState('isConnected', true)
+//     setupWeb3(provider as unknown as Provider)
+//   })
 
-  provider.on('accountsChanged', async (accounts: string[]) => {
-    console.log('Account changed', accounts)
+//   provider.on('accountsChanged', async (accounts: string[]) => {
+//     console.log('Account changed', accounts)
 
-    if (accounts.length === 0 && getState('isConnected')) {
-      await resetProvider()
-    }
+//     if (accounts.length === 0 && getState('isConnected')) {
+//       await resetProvider()
+//     }
 
-    const { setConnected } = useState()
-    const [address] = accounts
+//     const { setConnected } = useState()
+//     const [address] = accounts
 
-    setConnected(address, 'walletConnect')
-  })
+//     setConnected(address, 'walletConnect')
+//   })
 
-  setupWeb3(provider as unknown as Provider)
-}
+//   setupWeb3(provider as unknown as Provider)
+// }
 
-const resetProvider = async (): Promise<void> => {
-  await provider.disconnect()
-}
+// const resetProvider = async (): Promise<void> => {
+//   await provider.disconnect()
+// }
 
-const enableProvider = async (): Promise<void> => {
-  await provider.enable()
-}
+// const enableProvider = async (): Promise<void> => {
+//   await provider.enable()
+// }
 
-const getProvider = (): WalletConnectProvider => {
-  return provider
-}
+// const getProvider = (): WalletConnectProvider => {
+//   return provider
+// }
 
-export default function useWalletConnect(): {
-  resetProvider: () => Promise<void>
-  setupProvider: () => Promise<void>
-  enableProvider: () => Promise<void>
-  getProvider: () => WalletConnectProvider
-} {
-  return {
-    resetProvider,
-    setupProvider,
-    enableProvider,
-    getProvider,
-  }
-}
+// export default function useWalletConnect(): {
+//   resetProvider: () => Promise<void>
+//   setupProvider: () => Promise<void>
+//   enableProvider: () => Promise<void>
+//   getProvider: () => WalletConnectProvider
+// } {
+//   return {
+//     resetProvider,
+//     setupProvider,
+//     enableProvider,
+//     getProvider,
+//   }
+// }


### PR DESCRIPTION
After migration to Vite, the dist build was not working properly when importing WalletConnect lib.
I've disabled it so we can deploy this version on GitHub Pages.
We will soon migrate to WalletConnect2

https://app.clickup.com/t/2tt91az

-> Will merge now without approval to finalise the deployment - we can adjust stuff tmrw if needed.

