### PR TITLE
feat: siwe - optional date params

### DIFF
--- a/src/components/endpoints/__tests__/Sign.spec.ts
+++ b/src/components/endpoints/__tests__/Sign.spec.ts
@@ -116,6 +116,8 @@ test('can sign with ethereum', async () => {
   render(Sign)
 
   await fireEvent.click(screen.getByTestId('isSiwe'))
+  await fireEvent.click(screen.getByTestId('siwe.hasExpirationTime'))
+  await fireEvent.click(screen.getByTestId('siwe.hasNotBefore'))
   await fireEvent.update(
     screen.getByTestId('siwe.expirationDate'),
     '2022-09-02'


### PR DESCRIPTION
https://app.clickup.com/t/2tfghry

Since date params are optional there should be a way to disable them and not pass in the message. This will allow to test "default" 2min expiry time which ext will add in case of missing expiry time that is set by user.

![CleanShot 2022-09-12 at 12 26 45](https://user-images.githubusercontent.com/1100879/189665444-f6a28698-c5de-428f-8718-945620ce12b8.gif)
