### PR TITLE
chore: remove deprecated package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "@erc725/erc725.js": "0.14.4",
         "@lukso/lsp-factory.js": "2.3.3",
         "@lukso/lsp-smart-contracts": "0.6.2",
-        "@lukso/universalprofile-smart-contracts": "0.4.1",
         "@walletconnect/client": "1.8.0",
         "@walletconnect/qrcode-modal": "1.8.0",
         "@walletconnect/web3-provider": "1.8.0",
@@ -2859,26 +2858,6 @@
       "dependencies": {
         "@erc725/smart-contracts": "^3.1.2",
         "@openzeppelin/contracts": "^4.6.0",
-        "solidity-bytes-utils": "0.8.0"
-      }
-    },
-    "node_modules/@lukso/universalprofile-smart-contracts": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@lukso/universalprofile-smart-contracts/-/universalprofile-smart-contracts-0.4.1.tgz",
-      "integrity": "sha512-FEWKamXsbiBQnHx+9j9Csj9aUi3ae3mJTopsIBg7G/H+sTqPVA1jPaXtrWNxyEGSUxgKti+eaNypVK/EHHdQvw==",
-      "deprecated": "Renamed to @lukso/lsp-smart-contracts",
-      "dependencies": {
-        "@erc725/smart-contracts": "^2.1.6",
-        "@openzeppelin/contracts": "^4.3.0",
-        "solidity-bytes-utils": "0.8.0"
-      }
-    },
-    "node_modules/@lukso/universalprofile-smart-contracts/node_modules/@erc725/smart-contracts": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@erc725/smart-contracts/-/smart-contracts-2.3.0.tgz",
-      "integrity": "sha512-SPSlf9L4qU4NTKulquLnB7IEzBVpvGnP7Cuy2OntBL08a9ZmzyE9cvBk9Gx+faNFdwS89AxTwcaM/p08UFB6BQ==",
-      "dependencies": {
-        "@openzeppelin/contracts": "^4.3.1",
         "solidity-bytes-utils": "0.8.0"
       }
     },
@@ -20509,27 +20488,6 @@
         "@erc725/smart-contracts": "^3.1.2",
         "@openzeppelin/contracts": "^4.6.0",
         "solidity-bytes-utils": "0.8.0"
-      }
-    },
-    "@lukso/universalprofile-smart-contracts": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@lukso/universalprofile-smart-contracts/-/universalprofile-smart-contracts-0.4.1.tgz",
-      "integrity": "sha512-FEWKamXsbiBQnHx+9j9Csj9aUi3ae3mJTopsIBg7G/H+sTqPVA1jPaXtrWNxyEGSUxgKti+eaNypVK/EHHdQvw==",
-      "requires": {
-        "@erc725/smart-contracts": "^2.1.6",
-        "@openzeppelin/contracts": "^4.3.0",
-        "solidity-bytes-utils": "0.8.0"
-      },
-      "dependencies": {
-        "@erc725/smart-contracts": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/@erc725/smart-contracts/-/smart-contracts-2.3.0.tgz",
-          "integrity": "sha512-SPSlf9L4qU4NTKulquLnB7IEzBVpvGnP7Cuy2OntBL08a9ZmzyE9cvBk9Gx+faNFdwS89AxTwcaM/p08UFB6BQ==",
-          "requires": {
-            "@openzeppelin/contracts": "^4.3.1",
-            "solidity-bytes-utils": "0.8.0"
-          }
-        }
       }
     },
     "@metamask/eth-sig-util": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@erc725/erc725.js": "0.14.4",
     "@lukso/lsp-factory.js": "2.3.3",
     "@lukso/lsp-smart-contracts": "0.6.2",
-    "@lukso/universalprofile-smart-contracts": "0.4.1",
     "@walletconnect/client": "1.8.0",
     "@walletconnect/qrcode-modal": "1.8.0",
     "@walletconnect/web3-provider": "1.8.0",

--- a/src/components/endpoints/Assets.vue
+++ b/src/components/endpoints/Assets.vue
@@ -2,7 +2,7 @@
 import { getState } from '@/stores'
 import Notifications from '@/components/Notification.vue'
 import useNotifications from '@/compositions/useNotifications'
-import LSP7Mintable from '@lukso/universalprofile-smart-contracts/artifacts/LSP7Mintable.json'
+import LSP7Mintable from '@lukso/lsp-smart-contracts/artifacts/LSP7Mintable.json'
 import useWeb3 from '@/compositions/useWeb3'
 import { ref, watchEffect } from 'vue'
 import { Contract } from 'web3-eth-contract'

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -2,8 +2,8 @@ import { reactive } from 'vue'
 import { Store, Channel } from '@/types'
 import useWeb3 from '@/compositions/useWeb3'
 import { DEFAULT_GAS, DEFAULT_GAS_PRICE } from '@/helpers/config'
-import UniversalProfile from '@lukso/universalprofile-smart-contracts/artifacts/UniversalProfile.json'
-import KeyManager from '@lukso/universalprofile-smart-contracts/artifacts/LSP6KeyManager.json'
+import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json'
+import KeyManager from '@lukso/lsp-smart-contracts/artifacts/LSP6KeyManager.json'
 
 export const store = reactive<Store>({
   isConnected: false,


### PR DESCRIPTION
## What does this PR introduce?
- Removing the deprecated package `@lukso/universalprofile-smart-contracts`.

[`@lukso/universalprofile-smart-contracts`](https://www.npmjs.com/package/@lukso/universalprofile-smart-contracts) was deprecated 4 months ago and replaced with [`@lukso/lsp-smart-contracts`](https://www.npmjs.com/package/@lukso/lsp-smart-contracts)