### PR TITLE
fix: hash sign message before send

### DIFF
--- a/src/components/endpoints/Sign.vue
+++ b/src/components/endpoints/Sign.vue
@@ -10,7 +10,7 @@ import { getDate, getTime } from '@/utils/dateTime'
 
 const { notification, clearNotification, hasNotification, setNotification } =
   useNotifications()
-const { sign, recover, getWeb3 } = useWeb3()
+const { sign, recover, hashMessage } = useWeb3()
 
 const isPending = ref(false)
 const message = ref('sign message')
@@ -49,7 +49,9 @@ const onSign = async () => {
 
   try {
     isPending.value = true
-    signMessage.value = isSiwe.value ? createSiweMessage() : message.value
+    signMessage.value = hashMessage(
+      isSiwe.value ? createSiweMessage() : message.value
+    )
     console.info(signMessage.value)
     signResponse.value = await sign(signMessage.value, erc725AccountAddress)
     recovery.value = undefined
@@ -107,12 +109,9 @@ const handleResourceChange = (index: number, event: Event) => {
   siwe.value.resources[index] = (event.target as HTMLInputElement).value
 }
 
-const onRecover = async () => {
+const onRecover = () => {
   try {
-    recovery.value = await recover(
-      signMessage.value,
-      signResponse.value.signature
-    )
+    recovery.value = recover(signMessage.value, signResponse.value.signature)
 
     setNotification('Recover was successful')
   } catch (error) {
@@ -128,7 +127,7 @@ const onSignatureValidation = async () => {
   }
 
   try {
-    const messageHash = getWeb3().eth.accounts.hashMessage(signMessage.value)
+    const messageHash = hashMessage(signMessage.value)
     if (window.erc725Account) {
       // TODO: we should probably set the default gas price to undefined,
       // but it is not yet clear why view functions error on L16 when gasPrice is passed

--- a/src/components/endpoints/Sign.vue
+++ b/src/components/endpoints/Sign.vue
@@ -163,7 +163,7 @@ const onSignatureValidation = async () => {
           />
         </div>
       </div>
-      <div class="field">
+      <div v-show="false" class="field">
         <label class="checkbox">
           <input
             v-model="isSiwe"

--- a/src/components/endpoints/__tests__/Sign.spec.ts
+++ b/src/components/endpoints/__tests__/Sign.spec.ts
@@ -9,6 +9,7 @@ const mockSign = jest.fn()
 const mockRecover = jest.fn()
 const mockValidSignatureCall = jest.fn()
 const mockHashMessage = jest.fn()
+const mockSignature = '0x123'
 
 jest.mock('@/compositions/useWeb3', () => ({
   __esModule: true,
@@ -36,11 +37,8 @@ beforeEach(() => {
 })
 
 test('can sign message', async () => {
-  mockSign.mockReturnValue({
-    signature: '0x123',
-    address: '0x321',
-  })
-  mockHashMessage.mockReturnValue('0x213')
+  mockSign.mockReturnValue(mockSignature)
+  mockHashMessage.mockReturnValue('0x231')
   setState('address', '0x517216362D594516c6f96Ee34b2c502d65B847E4')
   render(Sign)
 
@@ -50,24 +48,16 @@ test('can sign message', async () => {
     'Message signed successfully'
   )
   expect(mockSign).toBeCalledWith(
-    '0x213',
+    '0x231',
     '0x517216362D594516c6f96Ee34b2c502d65B847E4'
   )
-  expect(mockSign).toReturnWith({
-    signature: '0x123',
-    address: '0x321',
-  })
-  expect(screen.getByTestId('signature')).toHaveTextContent('0x123')
-  expect(screen.getByTestId('sign-eoa')).toHaveTextContent('0x321')
+  expect(mockSign).toReturnWith(mockSignature)
+  expect(screen.getByTestId('signature')).toHaveTextContent(mockSignature)
 })
 
 test('can recovery message', async () => {
-  mockSign.mockReturnValue({
-    signature: '0x123',
-    address: '0x321',
-  })
+  mockSign.mockReturnValue(mockSignature)
   mockRecover.mockReturnValue('0x321')
-  mockHashMessage.mockReturnValue('0x213')
   setState('address', '0x517216362D594516c6f96Ee34b2c502d65B847E4')
   render(Sign)
 
@@ -77,16 +67,13 @@ test('can recovery message', async () => {
   expect(screen.getByTestId('notification')).toHaveTextContent(
     'Recover was successful'
   )
-  expect(mockRecover).toBeCalledWith('0x213', '0x123')
+  expect(mockRecover).toBeCalledWith('sign message', mockSignature)
   expect(mockRecover).toReturnWith('0x321')
   expect(screen.getByTestId('recovery-eoa')).toHaveTextContent('0x321')
 })
 
 test('can verify signature', async () => {
-  mockSign.mockReturnValue({
-    signature: '0x123',
-    address: '0x321',
-  })
+  mockSign.mockReturnValue(mockSignature)
   mockValidSignatureCall.mockReturnValue('0x1626ba7e')
   mockHashMessage.mockReturnValue('0x1626ba7e')
   setState('address', '0x517216362D594516c6f96Ee34b2c502d65B847E4')
@@ -104,10 +91,7 @@ test('can verify signature', async () => {
 })
 
 test.skip('can sign with ethereum', async () => {
-  mockSign.mockReturnValue({
-    signature: '0x123',
-    address: '0x321',
-  })
+  mockSign.mockReturnValue(mockSignature)
   setState('address', '0x517216362D594516c6f96Ee34b2c502d65B847E4')
   render(Sign)
 
@@ -164,10 +148,7 @@ Resources:
 - http://some-resource2.com`,
     '0x517216362D594516c6f96Ee34b2c502d65B847E4'
   )
-  expect(mockSign).toReturnWith({
-    signature: '0x123',
-    address: '0x321',
-  })
-  expect(screen.getByTestId('signature')).toHaveTextContent('0x123')
+  expect(mockSign).toReturnWith(mockSignature)
+  expect(screen.getByTestId('signature')).toHaveTextContent(mockSignature)
   expect(screen.getByTestId('sign-eoa')).toHaveTextContent('0x321')
 })

--- a/src/components/endpoints/__tests__/Sign.spec.ts
+++ b/src/components/endpoints/__tests__/Sign.spec.ts
@@ -16,13 +16,7 @@ jest.mock('@/compositions/useWeb3', () => ({
     sign: (message: string, address: string) => mockSign(message, address),
     recover: (message: string, signature: string) =>
       mockRecover(message, signature),
-    getWeb3: () => ({
-      eth: {
-        accounts: {
-          hashMessage: () => mockHashMessage(),
-        },
-      },
-    }),
+    hashMessage: () => mockHashMessage(),
   }),
 }))
 
@@ -46,6 +40,7 @@ test('can sign message', async () => {
     signature: '0x123',
     address: '0x321',
   })
+  mockHashMessage.mockReturnValue('0x213')
   setState('address', '0x517216362D594516c6f96Ee34b2c502d65B847E4')
   render(Sign)
 
@@ -55,7 +50,7 @@ test('can sign message', async () => {
     'Message signed successfully'
   )
   expect(mockSign).toBeCalledWith(
-    'sign message',
+    '0x213',
     '0x517216362D594516c6f96Ee34b2c502d65B847E4'
   )
   expect(mockSign).toReturnWith({
@@ -72,6 +67,7 @@ test('can recovery message', async () => {
     address: '0x321',
   })
   mockRecover.mockReturnValue('0x321')
+  mockHashMessage.mockReturnValue('0x213')
   setState('address', '0x517216362D594516c6f96Ee34b2c502d65B847E4')
   render(Sign)
 
@@ -81,7 +77,7 @@ test('can recovery message', async () => {
   expect(screen.getByTestId('notification')).toHaveTextContent(
     'Recover was successful'
   )
-  expect(mockRecover).toBeCalledWith('sign message', '0x123')
+  expect(mockRecover).toBeCalledWith('0x213', '0x123')
   expect(mockRecover).toReturnWith('0x321')
   expect(screen.getByTestId('recovery-eoa')).toHaveTextContent('0x321')
 })
@@ -107,7 +103,7 @@ test('can verify signature', async () => {
   expect(screen.getByTestId('magic-value')).toHaveTextContent('0x1626ba7e')
 })
 
-test('can sign with ethereum', async () => {
+test.skip('can sign with ethereum', async () => {
   mockSign.mockReturnValue({
     signature: '0x123',
     address: '0x321',

--- a/src/compositions/useWeb3.ts
+++ b/src/compositions/useWeb3.ts
@@ -57,12 +57,16 @@ const sign = async (message: string, address: string): Promise<string> => {
   return await web3.eth.sign(message, address)
 }
 
-const recover = async (message: string, signature: string): Promise<string> => {
+const recover = (message: string, signature: string): string => {
   return web3.eth.accounts.recover(message, signature)
 }
 
 const isAddress = (address: string): boolean => {
   return web3.utils.isAddress(address)
+}
+
+const hashMessage = (message: string): string => {
+  return web3.eth.accounts.hashMessage(message)
 }
 
 export default function useWeb3(): {
@@ -81,8 +85,9 @@ export default function useWeb3(): {
   accounts: () => Promise<string>
   requestAccounts: () => Promise<string[]>
   sign: (message: string, address: string) => Promise<string>
-  recover: (message: string, signature: string) => Promise<string>
+  recover: (message: string, signature: string) => string
   isAddress: (address: string) => boolean
+  hashMessage: (message: string) => string
 } {
   return {
     setupWeb3,
@@ -96,5 +101,6 @@ export default function useWeb3(): {
     sign,
     recover,
     isAddress,
+    hashMessage,
   }
 }


### PR DESCRIPTION
https://app.clickup.com/t/2z4j7cc
https://github.com/lukso-network/universalprofile-extension/pull/508
https://github.com/MetaMask/metamask-extension/issues/15857

## test dApp
Added additional hashing using `web3.eth.accounts.hashMessage(message)` from web3 library to the sign message before send via `eth_sign`. There is also differentiation between validation check for ext and Metamask which compare recovered EoA with connected to dApp.

## Extension
To be compatible with Metamask we will need to apply some changes in our RPC. 

### 1. Change response from extension which now return signature and EoA address:

```
{
  signature: string
  address: string
}
```
into:
```
signature: string
```
### 2. Change how we sign message from `signPersonalMessage` to `signMessage`.

As a result `eth_sign` with hash works with recover and validation in current setup:

<img width="400" alt="CleanShot 2022-09-16 at 16 38 34@2x" src="https://user-images.githubusercontent.com/1100879/190665021-9e38cbcd-f8ad-4e25-9c74-c677d259d0ea.png">
<img width="400" alt="CleanShot 2022-09-16 at 16 39 03@2x" src="https://user-images.githubusercontent.com/1100879/190665122-68f11426-8750-4819-8249-87bcdaad8791.png">
Recovered EoA is correct controller key address:
<img width="400" alt="CleanShot 2022-09-16 at 16 57 41@2x" src="https://user-images.githubusercontent.com/1100879/190669308-e284c70d-adf8-44c2-b9f6-74c601e723e6.png">

<img src="https://user-images.githubusercontent.com/1100879/190665252-3cbacccc-91ae-4244-aac1-035e9e284196.png" width="400" />

## Metamask  
Results in Metamask are similar:

<img width="400" alt="CleanShot 2022-09-16 at 16 40 44@2x" src="https://user-images.githubusercontent.com/1100879/190665556-ad058d70-21ce-41d1-afb6-11db19f1210e.png">
<img width="400" alt="CleanShot 2022-09-16 at 16 41 28@2x" src="https://user-images.githubusercontent.com/1100879/190665611-5bd24608-8434-4c9c-8eab-fe007d079c29.png">
<img src="https://user-images.githubusercontent.com/1100879/190665747-6c448524-d672-4ee4-8c71-02916fed6be5.png" width="400" />

---
SIWE will be hidden till it's fixed in next PR using `eth_signTypedData_v4`

