### PR TITLE
feat: update vite config to add support for require('buffer')

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
       http: 'stream-http',
       https: 'https-browserify',
       stream: 'stream-browserify',
+      buffer: 'buffer/  '
     },
   },
   build: {


### PR DESCRIPTION
Add support for require('buffer')

This will now return the buffer implementation from require('buffer')
but no longer assume or pollute the window globals. Similar things are
already happening to 'process/buffer'. I also had problems with vite dev
and some existing browser extension. Specifically LastPass for some odd reason.
