### PR TITLE
fix: changed wallet connect bridge

### DIFF
--- a/src/compositions/useWalletConnect.ts
+++ b/src/compositions/useWalletConnect.ts
@@ -14,7 +14,7 @@ const setupProvider = async (): Promise<void> => {
     rpc: {
       [DEFAULT_NETWORK_CONFIG.chainId]: DEFAULT_NETWORK_CONFIG.rpc.url,
     },
-    bridge: 'https://bridge.walletconnect.org/',
+    bridge: 'https://safe-walletconnect.safe.global/',
     chainId: DEFAULT_NETWORK_CONFIG.chainId,
   })
 


### PR DESCRIPTION
We started to have some issues and in particular @artkachenko has reached a request limit. After some investigation, I've found out that the previous bridge does work but on a slightly different domain - `https://safe-walletconnect.safe.global/`

I wasn't able to find any public announcements about that change of domain but opening `https://safe-walletconnect.gnosis.io` in the browser redirects to `https://safe-walletconnect.safe.global/`.

<img width="528" alt="Screenshot_2022-10-31_at_13 15 59" src="https://user-images.githubusercontent.com/36865532/199187191-c18c8cfe-daac-4a4b-ab2f-2078844188b9.png">
