### PR TITLE
fix: Add cloudflare proxy and small misc fixes.

### DIFF
--- a/src/components/shared/ParamField.vue
+++ b/src/components/shared/ParamField.vue
@@ -78,6 +78,9 @@ function validate(value: any): { value: any; error?: string } {
       if (/^0x([0-9a-f][0-9a-f])*/i.test(value)) {
         return { value }
       }
+      if (!value) {
+        return { value: '0x' }
+      }
       return { value, error: 'Invalid bytes value' }
     case 'uint256':
     case 'uint128':

--- a/src/helpers/config.ts
+++ b/src/helpers/config.ts
@@ -49,4 +49,4 @@ export const PRIVATE_KEY =
 export const DEFAULT_NETWORK_CONFIG = NETWORKS[DEFAULT_NETWORK]
 
 export const SIGNATURE_LOOKUP_URL =
-  'https://www.4byte.directory/api/v1/signatures/'
+  'https://dawn-band-b9c5.andreas3255.workers.dev/'

--- a/src/helpers/tokenUtils.ts
+++ b/src/helpers/tokenUtils.ts
@@ -167,12 +167,23 @@ export const detectLSP = async (
     const { getInstance } = useErc725()
 
     const erc725 = await getInstance(contractAddress)
-    const [{ value: name }, { value: symbol }] = await erc725.fetchData([
+    let [{ value: name }, { value: symbol }] = await erc725.fetchData([
       'LSP4TokenName',
       'LSP4TokenSymbol',
     ])
-    if (typeof name !== 'string' || typeof symbol !== 'string') {
-      throw new Error('Unable to get name and/or symbol')
+    if (typeof name !== 'string') {
+      try {
+        name = (await contract.methods.name().call()) as string
+      } catch (err) {
+        name = '<undef>'
+      }
+    }
+    if (typeof symbol !== 'string') {
+      try {
+        symbol = (await contract.methods.symbol().call()) as string
+      } catch (err) {
+        symbol = '<undef>'
+      }
     }
     let shortType: string = lspType
     switch (shortType) {


### PR DESCRIPTION
Return 0x when decoding an empty bytes
Point to test cfworker proxy
Display <undef> when unable to retrieve symbol and/or name for LSP7/LSP8
