### PR TITLE
feat: select network used by DApp

### DIFF
--- a/src/components/Connect.vue
+++ b/src/components/Connect.vue
@@ -12,6 +12,7 @@ import {
   WINDOW_ETHEREUM,
 } from '@/helpers/config'
 import useWalletConnectV2 from '@/compositions/useWalletConnectV2'
+import { sliceAddress } from '@/utils/sliceAddress'
 
 const { setupWeb3, accounts, requestAccounts } = useWeb3()
 

--- a/src/components/Connect.vue
+++ b/src/components/Connect.vue
@@ -11,13 +11,11 @@ import {
   WALLET_CONNECT,
   WINDOW_ETHEREUM,
 } from '@/helpers/config'
-import { sliceAddress } from '@/utils/sliceAddress'
 import useWalletConnectV2 from '@/compositions/useWalletConnectV2'
-import { isDesktop } from '@/utils/isDesktop'
 
 const { setupWeb3, accounts, requestAccounts } = useWeb3()
 
-const { resetWCV2Provider, setupWCV2Provider, openWCV2Modal, getWCV2Provider } =
+const { resetWCV2Provider, setupWCV2Provider, openWCV2Modal } =
   useWalletConnectV2()
 const { setDisconnected, setConnected } = useState()
 const { close, toggle } = useDropdown()

--- a/src/components/endpoints/Accounts.vue
+++ b/src/components/endpoints/Accounts.vue
@@ -5,6 +5,7 @@ import useWalletConnectV2 from '@/compositions/useWalletConnectV2'
 import { getState, useState } from '@/stores'
 import useWeb3 from '@/compositions/useWeb3'
 import {
+  getSelectedNetworkConfig,
   UP_CONNECTED_ADDRESS,
   WALLET_CONNECT,
   WINDOW_ETHEREUM,
@@ -19,6 +20,7 @@ const { notification, clearNotification, hasNotification, setNotification } =
 const { setDisconnected, setConnected, recalcTokens } = useState()
 const { setupWeb3, requestAccounts } = useWeb3()
 const hasExtension = ref<boolean>(!!window.ethereum)
+const selectedNetworkConfig = getSelectedNetworkConfig()
 
 watch(
   () => !!window.ethereum,
@@ -91,6 +93,9 @@ const handleRefresh = (e: Event) => {
   <div class="tile is-4 is-parent">
     <div class="tile is-child box">
       <p class="is-size-5 has-text-weight-bold mb-1">Connect</p>
+      <div style="padding-top: 8px; padding-bottom: 8px">
+        DApp uses <b>{{ selectedNetworkConfig.name }}</b> network.
+      </div>
       <div class="field">
         <button
           class="button is-primary is-rounded mb-1"

--- a/src/components/endpoints/SendTransaction.vue
+++ b/src/components/endpoints/SendTransaction.vue
@@ -10,14 +10,14 @@ import useWeb3 from '@/compositions/useWeb3'
 import {
   DEFAULT_GAS,
   DEFAULT_GAS_PRICE,
-  DEFAULT_NETWORK,
+  getSelectedNetworkConfig,
 } from '@/helpers/config'
 import ContractFunction from '@/components/shared/ContractFunction.vue'
 import { MethodSelect, MethodType } from '@/helpers/functionUtils'
 import { NETWORKS } from '@/helpers/config'
 import { LSPType } from '@/helpers/tokenUtils'
 
-const { sampleUP } = NETWORKS[DEFAULT_NETWORK]
+const { sampleUP } = getSelectedNetworkConfig()
 const { notification, clearNotification, hasNotification, setNotification } =
   useNotifications()
 const { sendTransaction, getBalance } = useWeb3()

--- a/src/components/shared/LSPSelect.vue
+++ b/src/components/shared/LSPSelect.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { getState } from '@/stores'
 import { LSPType, TokenInfo } from '@/helpers/tokenUtils'
-import { DEFAULT_NETWORK, NETWORKS } from '@/helpers/config'
+import { getSelectedNetworkConfig } from '@/helpers/config'
 import { ref, computed, onMounted, watch } from 'vue'
 
 type Props = {
@@ -27,7 +27,7 @@ const {
   erc777TokenWithEip165,
   erc777TokenWithoutEip165,
   erc721TokenWithEip165,
-} = NETWORKS[DEFAULT_NETWORK]
+} = getSelectedNetworkConfig()
 const emits = defineEmits<Emits>()
 const props = defineProps<Props>()
 const selected = ref<string | undefined>(props.address)

--- a/src/compositions/useErc725.ts
+++ b/src/compositions/useErc725.ts
@@ -6,13 +6,14 @@ import lsp9Schema from '@erc725/erc725.js/schemas/LSP9Vault.json'
 import { Permissions } from '@erc725/erc725.js/build/main/src/types/Method'
 import { FetchDataOutput } from '@erc725/erc725.js/build/main/src/types/decodeData'
 import Web3 from 'web3'
-import { DEFAULT_NETWORK_CONFIG } from '@/helpers/config'
+import { getSelectedNetworkConfig } from '@/helpers/config'
 
 window.ERC725 = ERC725
 
-const provider = new Web3.providers.HttpProvider(DEFAULT_NETWORK_CONFIG.rpc.url)
+const defaultNetworkConfig = getSelectedNetworkConfig()
+const provider = new Web3.providers.HttpProvider(defaultNetworkConfig.rpc.url)
 const config = {
-  ipfsGateway: DEFAULT_NETWORK_CONFIG.ipfs.url,
+  ipfsGateway: defaultNetworkConfig.ipfs.url,
 }
 
 const getInstance = (address: string) => {

--- a/src/compositions/useLspFactory.ts
+++ b/src/compositions/useLspFactory.ts
@@ -8,7 +8,7 @@ import {
 } from '@lukso/lsp-factory.js'
 
 import { UploadOptions } from '@lukso/lsp-factory.js/build/main/src/lib/interfaces/profile-upload-options'
-import { DEFAULT_NETWORK_CONFIG } from '@/helpers/config'
+import { getSelectedNetworkConfig } from '@/helpers/config'
 import {
   DeployedLSP7DigitalAsset,
   DeployedLSP8IdentifiableDigitalAsset,
@@ -24,7 +24,7 @@ const getFactory = (): LSPFactory => {
 
 const setupLSPFactory = (): void => {
   lspFactory = new LSPFactory(window.ethereum as any, {
-    chainId: DEFAULT_NETWORK_CONFIG.chainId,
+    chainId: getSelectedNetworkConfig().chainId,
   })
 }
 

--- a/src/compositions/useWalletConnectV2.ts
+++ b/src/compositions/useWalletConnectV2.ts
@@ -3,7 +3,8 @@ import { setState, useState, getState } from '@/stores'
 import useWeb3 from '@/compositions/useWeb3'
 import { provider as Provider } from 'web3-core'
 import {
-  DEFAULT_NETWORK_CONFIG,
+  getSelectedNetworkConfig,
+  NETWORKS,
   WALLET_CONNECT,
   WALLET_CONNECT_PROJECT_ID,
 } from '@/helpers/config'
@@ -17,7 +18,7 @@ const setupWCV2Provider = async (): Promise<void> => {
   const { setupWeb3 } = useWeb3()
   provider = await EthereumProvider.init({
     projectId: WALLET_CONNECT_PROJECT_ID,
-    chains: [DEFAULT_NETWORK_CONFIG.chainId],
+    chains: Object.entries(NETWORKS).map(net => net[1].chainId),
     methods: [
       'eth_getAccounts',
       'eth_getBalance',

--- a/src/compositions/useWalletConnectV2.ts
+++ b/src/compositions/useWalletConnectV2.ts
@@ -53,7 +53,6 @@ const setupWCV2Provider = async (): Promise<void> => {
     if (error) {
       throw error
     }
-
     setupWeb3(provider as unknown as Provider)
     setState('isConnected', true)
   })
@@ -75,7 +74,6 @@ const setupWCV2Provider = async (): Promise<void> => {
     if (error) {
       throw error
     }
-
     setupWeb3(provider as unknown as Provider)
     setState('isConnected', true)
   })
@@ -107,7 +105,11 @@ const setupWCV2Provider = async (): Promise<void> => {
  */
 const resetWCV2Provider = async (): Promise<void> => {
   if (provider) {
-    await provider.disconnect()
+    try {
+      await provider.disconnect()
+    } catch (error) {
+      console.warn(`WalletConnect V2 disconnection error: ${error}`)
+    }
   } else {
     console.warn(
       'Provider is not set up. Please, call `setupWCV2Provider` first.'
@@ -120,7 +122,11 @@ const resetWCV2Provider = async (): Promise<void> => {
  */
 const openWCV2Modal = async (): Promise<void> => {
   if (provider) {
-    await provider.connect()
+    try {
+      await provider.connect()
+    } catch (error) {
+      console.warn(`WalletConnect V2 connection error: ${error}`)
+    }
   } else {
     console.warn(
       'Provider is not set up. Please, call `setupWCV2Provider` first.'

--- a/src/compositions/useWeb3.ts
+++ b/src/compositions/useWeb3.ts
@@ -3,7 +3,7 @@ import { provider as Provider } from 'web3-core'
 import { AbiItem, isAddress as baseIsAddress } from 'web3-utils'
 import { Contract, ContractOptions } from 'web3-eth-contract'
 import { TransactionConfig, TransactionReceipt } from 'web3-core'
-import { DEFAULT_NETWORK_CONFIG, setNetworkConfig } from '@/helpers/config'
+import { resetNetworkConfig, setNetworkConfig } from '@/helpers/config'
 
 let web3: Web3
 
@@ -17,7 +17,7 @@ const setupWeb3 = async (provider: Provider): Promise<void> => {
     })
     .catch(() => {
       // Ignore error
-      setNetworkConfig(DEFAULT_NETWORK_CONFIG.chainId)
+      resetNetworkConfig()
     })
 }
 

--- a/src/helpers/config.ts
+++ b/src/helpers/config.ts
@@ -20,6 +20,7 @@ export const DEFAULT_GAS_PRICE = '10000000000'
 export const MAGICVALUE = '0x1626ba7e'
 
 export const DEFAULT_NETWORK: NetworkType = 'testnet'
+export const SELECTED_NETWORK_KEY = 'selected-network'
 
 export const NETWORKS: { [K in NetworkType]: NetworkInfo } = {
   l16: {
@@ -95,12 +96,16 @@ export function setNetworkConfig(inChainId: number): void {
   const network = Object.entries(NETWORKS).find(
     ([, { chainId }]) => chainId === inChainId
   )
+  let networkKey
   if (network) {
+    networkKey = network[1].name
     DEFAULT_NETWORK_CONFIG = NETWORKS[network[0] as NetworkType]
   } else {
-    console.warn('Unknown network defaulting to l16')
-    DEFAULT_NETWORK_CONFIG = NETWORKS['l16']
+    console.warn('Unknown network defaulting to testnet')
+    DEFAULT_NETWORK_CONFIG = NETWORKS.testnet
+    networkKey = 'testnet'
   }
+  localStorage.setItem(SELECTED_NETWORK_KEY, networkKey)
 }
 
 export const SIGNATURE_LOOKUP_URL =

--- a/src/helpers/config.ts
+++ b/src/helpers/config.ts
@@ -19,8 +19,8 @@ export const DEFAULT_GAS_PRICE = '10000000000'
 
 export const MAGICVALUE = '0x1626ba7e'
 
-export const DEFAULT_NETWORK: NetworkType = 'testnet'
-export const SELECTED_NETWORK_KEY = 'selected-network'
+const DEFAULT_NETWORK: NetworkType = 'testnet'
+const SELECTED_NETWORK_KEY = 'selected-network'
 
 export const NETWORKS: { [K in NetworkType]: NetworkInfo } = {
   l16: {
@@ -91,7 +91,6 @@ export const NETWORKS: { [K in NetworkType]: NetworkInfo } = {
 export const PRIVATE_KEY =
   '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
 
-export let DEFAULT_NETWORK_CONFIG = NETWORKS[DEFAULT_NETWORK]
 export function setNetworkConfig(inChainId: number): void {
   const network = Object.entries(NETWORKS).find(
     ([, { chainId }]) => chainId === inChainId
@@ -99,13 +98,30 @@ export function setNetworkConfig(inChainId: number): void {
   let networkKey
   if (network) {
     networkKey = network[1].name
-    DEFAULT_NETWORK_CONFIG = NETWORKS[network[0] as NetworkType]
   } else {
-    console.warn('Unknown network defaulting to testnet')
-    DEFAULT_NETWORK_CONFIG = NETWORKS.testnet
-    networkKey = 'testnet'
+    console.warn(`Unknown network. Defaulting to '${DEFAULT_NETWORK}'.`)
+    networkKey = DEFAULT_NETWORK
   }
   localStorage.setItem(SELECTED_NETWORK_KEY, networkKey)
+}
+
+export function resetNetworkConfig(): void {
+  localStorage.setItem(SELECTED_NETWORK_KEY, DEFAULT_NETWORK)
+}
+
+export function getSelectedNetworkType(): NetworkType {
+  const selectedNetwork = localStorage.getItem(
+    SELECTED_NETWORK_KEY
+  ) as NetworkType
+  if (selectedNetwork) {
+    return selectedNetwork
+  } else {
+    return DEFAULT_NETWORK
+  }
+}
+
+export function getSelectedNetworkConfig(): NetworkInfo {
+  return NETWORKS[getSelectedNetworkType()]
 }
 
 export const SIGNATURE_LOOKUP_URL =

--- a/src/helpers/customRequest.ts
+++ b/src/helpers/customRequest.ts
@@ -1,18 +1,19 @@
 import useWalletConnectV2 from '@/compositions/useWalletConnectV2'
-import { isDesktop } from '@/utils/isDesktop'
+import { MEANS_OF_CONNECTION, WALLET_CONNECT } from '@/helpers/config'
 
 const { getWCV2Provider, sendCustomWCV2Request } = useWalletConnectV2()
 
 const sendRequest = async (request: any): Promise<any> => {
-  if (isDesktop()) {
-    return await (window.ethereum as any)?.request(request)
-  } else {
+  const channel = localStorage.getItem(MEANS_OF_CONNECTION)
+  const isWalletConnectUsed = channel === WALLET_CONNECT
+  if (isWalletConnectUsed) {
     const wcv2Provider = getWCV2Provider()
-    if (wcv2Provider && wcv2Provider.connected) {
+    if (wcv2Provider?.connected) {
       return await sendCustomWCV2Request(request)
     }
+  } else {
+    return await (window.ethereum as any)?.request(request)
   }
-  return await (window.ethereum as any)?.request(request)
 }
 
 export { sendRequest }

--- a/src/helpers/localstorage.ts
+++ b/src/helpers/localstorage.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_NETWORK_CONFIG } from './config'
+import { getSelectedNetworkConfig } from './config'
 
 const IPFS_PREFIX = 'ipfs://'
 
@@ -9,11 +9,11 @@ export function getAndPrepareAllIpfsItems(): {
   const values: { url: string; profile: string; timestamp: number }[] = []
   const keys = Object.keys(localStorage)
   let i = keys.length
-
+  const selectedNetwork = getSelectedNetworkConfig()
   while (i--) {
     if (keys[i].startsWith(IPFS_PREFIX)) {
       values.push({
-        url: keys[i].replace(IPFS_PREFIX, DEFAULT_NETWORK_CONFIG.ipfs.url),
+        url: keys[i].replace(IPFS_PREFIX, selectedNetwork.ipfs.url),
         profile: JSON.parse(localStorage.getItem(keys[i]) as string),
         timestamp: Date.now(),
       })

--- a/src/helpers/tokenUtils.ts
+++ b/src/helpers/tokenUtils.ts
@@ -10,9 +10,9 @@ import useErc725 from '@/compositions/useErc725'
 import { eip165ABI } from '@/abis/eip165ABI'
 import { erc20ABI } from '@/abis/erc20ABI'
 import { store, setState } from '@/stores/index'
-import { DEFAULT_NETWORK, NETWORKS } from '@/helpers/config'
+import { getSelectedNetworkConfig } from '@/helpers/config'
 
-const { lsp7TokenDivisible, lsp7TokenNonDivisible } = NETWORKS[DEFAULT_NETWORK]
+const { lsp7TokenDivisible, lsp7TokenNonDivisible } = getSelectedNetworkConfig()
 
 const getSupportedStandardObject = (schemas: ERC725JSONSchema[]) => {
   try {

--- a/src/utils/createLinks.ts
+++ b/src/utils/createLinks.ts
@@ -1,11 +1,11 @@
-import { DEFAULT_NETWORK_CONFIG } from '@/helpers/config'
+import { getSelectedNetworkConfig } from '@/helpers/config'
 
 export function createIpfsLink(url: string): string {
-  return url.replace('ipfs://', DEFAULT_NETWORK_CONFIG.ipfs.url)
+  return url.replace('ipfs://', getSelectedNetworkConfig().ipfs.url)
 }
 
 export function createBlockScoutLink(hash: string, isTx = false): string {
-  return `${DEFAULT_NETWORK_CONFIG.blockscout.url}/${
+  return `${getSelectedNetworkConfig().blockscout.url}/${
     isTx ? 'tx' : 'address'
   }/${hash}`
 }

--- a/src/views/profile/Deploy.vue
+++ b/src/views/profile/Deploy.vue
@@ -4,7 +4,7 @@ import Notifications from '@/components/Notification.vue'
 import ProfileListIpfs from '@/components/profile/profile-list-ipfs/ProfileListIpfs.vue'
 import { ref } from 'vue'
 import useNotifications from '@/compositions/useNotifications'
-import { DEFAULT_NETWORK, NETWORKS } from '@/helpers/config'
+import { getSelectedNetworkConfig } from '@/helpers/config'
 import { useLspFactory } from '@/compositions/useLspFactory'
 import ProfileModal from '@/components/modals/ProfileModal.vue'
 import { createBlockScoutLink } from '@/utils/createLinks'
@@ -26,7 +26,7 @@ const profileDeploymentEvents = ref<DeploymentEvent[]>([])
 const isLoading = ref(false)
 const { deployUniversalProfile } = useLspFactory()
 const uploadedProfiles = ref(getAndPrepareAllIpfsItems())
-const uploadTarget = ref(NETWORKS[DEFAULT_NETWORK].ipfs.url)
+const uploadTarget = ref(getSelectedNetworkConfig().ipfs.url)
 
 const deploy = async (controllerKey: string) => {
   isLoading.value = true

--- a/src/views/profile/Detail.vue
+++ b/src/views/profile/Detail.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { DEFAULT_NETWORK_CONFIG } from '@/helpers/config'
+import { getSelectedNetworkConfig } from '@/helpers/config'
 import { onMounted, ref, watch } from 'vue'
 import useErc725 from '@/compositions/useErc725'
 import { useRoute, RouteLocationNormalizedLoaded, useRouter } from 'vue-router'
@@ -53,7 +53,7 @@ const getProfileDataFromIPFS = async (ipfsHash: string) => {
     return false
   }
   try {
-    const result = await fetch(DEFAULT_NETWORK_CONFIG.ipfs.url + ipfsHash)
+    const result = await fetch(getSelectedNetworkConfig().ipfs.url + ipfsHash)
     dataSource.value = 'IPFS'
     profileData.value = await result.json()
   } catch (err: unknown) {

--- a/src/views/profile/Upload.vue
+++ b/src/views/profile/Upload.vue
@@ -2,7 +2,7 @@
 import { ref, computed } from 'vue'
 import { getAndPrepareAllIpfsItems } from '@/helpers/localstorage'
 import { filesize } from 'filesize'
-import { DEFAULT_NETWORK, NETWORKS } from '@/helpers/config'
+import { getSelectedNetworkConfig } from '@/helpers/config'
 import Notifications from '@/components/Notification.vue'
 import useNotifications from '@/compositions/useNotifications'
 import { useLspFactory } from '@/compositions/useLspFactory'
@@ -25,7 +25,7 @@ const name = ref('')
 const description = ref('')
 const links = ref<ProfileLinks[]>([])
 const tags = ref<string[]>([])
-const uploadTarget = ref(NETWORKS[DEFAULT_NETWORK].ipfs.url)
+const uploadTarget = ref(getSelectedNetworkConfig().ipfs.url)
 const uploadResult = ref()
 const uploadedProfiles = ref(getAndPrepareAllIpfsItems())
 


### PR DESCRIPTION
_See the video of how it works below._

With #117 DApp began to use only test net for its internal requests like:
```typescript
const upOwner = await window.erc725Account.methods.owner().call()
```

This brings up quite a few issues for one simple reason - we can connect two applications that use different networks and that breaks everything. 
Example: when `erc725Account` is from L16 and DApp tries to use `methods.owner().call()` it expects the address of `erc725Account` to exist on `testnet` and sends requests to `testnet` RPC providers. From that line on everything stops working because there's no such address on `testnet`.

-----

Also, there are a few other bug fixes like:
- using `channel` instead of `isDesktop` for `sendRequest` function to decide how to send request;
- in `useWalletConnectV2` wrapped a few functions in try-catch.

-----

https://github.com/lukso-network/universalprofile-test-dapp/assets/36865532/339045eb-5220-42cb-93fe-96404f917d86


