### PR TITLE
fix: replace selector by `setDataBatch`

### DIFF
--- a/src/components/endpoints/SendTransaction.vue
+++ b/src/components/endpoints/SendTransaction.vue
@@ -211,7 +211,7 @@ const methods: MethodSelect[] = [
   },
   {
     label: '🎛️ SetData',
-    call: 'setData',
+    call: 'setDataBatch',
     hasSpecs: [
       LSPType.UP,
       LSPType.LSP3ProfileMetadata,


### PR DESCRIPTION
Incorrect selector is computed when selecting `setData` in the list and the parameters are array

## Current behaviour

<img width="542" alt="image" src="https://github.com/lukso-network/universalprofile-test-dapp/assets/31145285/9b778455-e7a7-4990-8114-5f45aa26a757">

## New behaviour

Fix it with the correct selector ✅ 

<img width="566" alt="image" src="https://github.com/lukso-network/universalprofile-test-dapp/assets/31145285/1cdc8552-6528-4a0b-a808-4be82748dbb6">
