### PR TITLE
chore: logging transaction hash

### DIFF
--- a/src/compositions/useWeb3Connection.ts
+++ b/src/compositions/useWeb3Connection.ts
@@ -132,8 +132,11 @@ const sendTransaction = (
 ): Promise<TransactionReceipt> => {
   return web3.eth
     .sendTransaction(transaction)
+    .on('transactionHash', hash => {
+      console.log('Transaction hash:', hash)
+    })
     .on('receipt', (receipt: any) => {
-      console.log(receipt)
+      console.log('Transaction receipt:', receipt)
     })
     .once('sending', payload => {
       console.log(JSON.stringify(payload, null, 2))


### PR DESCRIPTION
Logging transaction hash once it's received as a response to eth_sendTransaction. 

It looks like this:

![Screenshot 2024-05-16 at 19 06 28](https://github.com/lukso-network/universalprofile-test-dapp/assets/36865532/cce787e9-8df3-4a7c-9a5d-58ea5713ca50)
