### PR TITLE
fix: transaction.data field bytes decoding

### DIFF
--- a/src/components/endpoints/Assets.vue
+++ b/src/components/endpoints/Assets.vue
@@ -119,8 +119,9 @@ const create = async () => {
           tokenIdFormat: tokenIdType.value,
         }
         console.log(digitalAssetData)
-        deployedAsset =
-          await deployLSP8IdentifiableDigitalAsset(digitalAssetData)
+        deployedAsset = await deployLSP8IdentifiableDigitalAsset(
+          digitalAssetData
+        )
         console.log(
           'Deployed asset',
           deployedAsset.LSP8IdentifiableDigitalAsset

--- a/src/components/endpoints/Assets.vue
+++ b/src/components/endpoints/Assets.vue
@@ -119,7 +119,7 @@ const create = async () => {
           tokenIdFormat: tokenIdType.value,
         }
         console.log(digitalAssetData)
-        deployedAsset = 
+        deployedAsset =
           await deployLSP8IdentifiableDigitalAsset(digitalAssetData)
         console.log(
           'Deployed asset',

--- a/src/components/endpoints/Assets.vue
+++ b/src/components/endpoints/Assets.vue
@@ -119,9 +119,8 @@ const create = async () => {
           tokenIdFormat: tokenIdType.value,
         }
         console.log(digitalAssetData)
-        deployedAsset = await deployLSP8IdentifiableDigitalAsset(
-          digitalAssetData
-        )
+        deployedAsset = 
+          await deployLSP8IdentifiableDigitalAsset(digitalAssetData)
         console.log(
           'Deployed asset',
           deployedAsset.LSP8IdentifiableDigitalAsset

--- a/src/components/shared/ContractFunction.vue
+++ b/src/components/shared/ContractFunction.vue
@@ -124,7 +124,9 @@ const computedCall = computed<string>(() => {
   return props.dataDecoder
     ? `${reactiveData.items?.map(({ name, type }) => `${type} ${name}`).join(', ')}`
     : reactiveData.call
-      ? `${reactiveData.call}(${reactiveData.items?.map(({ name, type }) => `${type} ${name}`).join(', ')})`
+      ? `${reactiveData.call}(${reactiveData.items
+          ?.map(({ name, type }) => `${type} ${name}`)
+          .join(', ')})`
       : ''
 })
 
@@ -175,7 +177,10 @@ const makeBytes = (value: string, type: string) => {
       return padLeft(hex, bytesCount * 2)
     }
     if (/^0x[0-9a-f]*$/i.test(value)) {
-      return padRight(value, bytesCount * 2)
+      if (/^bytes/.test(type)) {
+        return padRight(value, bytesCount * 2)
+      }
+      return padLeft(value, bytesCount * 2)
     }
     if (/^\w*(:.*,.*)?$/.test(value)) {
       const items = (value || '').split(',')

--- a/src/components/shared/ContractFunction.vue
+++ b/src/components/shared/ContractFunction.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { decodeData, MethodType } from '@/helpers/functionUtils'
 import { reactive, computed, watch, onMounted } from 'vue'
-import { toWei, Unit, padLeft, numberToHex } from 'web3-utils'
+import { toWei, Unit, padLeft, padRight, numberToHex } from 'web3-utils'
 import ParamField from './ParamField.vue'
 import useWeb3Connection from '@/compositions/useWeb3Connection'
 import ERC725 from '@erc725/erc725.js'
@@ -175,7 +175,7 @@ const makeBytes = (value: string, type: string) => {
       return padLeft(hex, bytesCount * 2)
     }
     if (/^0x[0-9a-f]*$/i.test(value)) {
-      return padLeft(value, bytesCount * 2)
+      return padRight(value, bytesCount * 2)
     }
     if (/^\w*(:.*,.*)?$/.test(value)) {
       const items = (value || '').split(',')

--- a/src/components/shared/ParamField.vue
+++ b/src/components/shared/ParamField.vue
@@ -1,6 +1,13 @@
 <script setup lang="ts">
 import { reactive, computed, watch } from 'vue'
-import { toWei, Unit, padLeft, numberToHex, hexToNumber } from 'web3-utils'
+import {
+  toWei,
+  Unit,
+  padLeft,
+  padRight,
+  numberToHex,
+  hexToNumber,
+} from 'web3-utils'
 import ERC725, { ERC725JSONSchema } from '@erc725/erc725.js'
 import LSPSelect from '@/components/shared/LSPSelect.vue'
 import { BN } from 'bn.js'
@@ -378,7 +385,7 @@ const makeBytes32 = (index: number, force = false) => {
       }
     }
     if (/^0x[0-9a-f]*$/i.test(item.value)) {
-      return padLeft(item.value, 64)
+      return padRight(item.value, 64)
     }
     if (/^[0-9]*$/.test(item.value)) {
       return padLeft(item.value, 64)

--- a/src/helpers/functionUtils.ts
+++ b/src/helpers/functionUtils.ts
@@ -90,7 +90,9 @@ export const decodeData = async (
       signatureCache = await caches.open(SIGNATURE_CACHE)
     } catch {}
     const url = getSelectorLookupURL(selector)
-    const functionSignatureResponse = await signatureCache?.match(url)
+    // Use a different cache key instead to fix problem with wrong response.
+    const functionKey = `${url}/decoded`
+    const functionSignatureResponse = await signatureCache?.match(functionKey)
 
     let functionSignatures: string[] = []
     if (functionSignatureResponse) {
@@ -152,7 +154,10 @@ export const decodeData = async (
                   call in { setData: true, getData: true },
               })),
             }
-            await signatureCache?.put(url, new Response(JSON.stringify(item)))
+            await signatureCache?.put(
+              functionKey,
+              new Response(JSON.stringify(item))
+            )
             return item
           }
         } catch (err) {


### PR DESCRIPTION
Fixing logic of decoding data pasted into `transaction.data` field.

Issues:
- we have a cache with functions pulled from 4byte.directory. With those functions **we also keep decoded values of the pasted function call**. If you paste `execute(uint256,address,uint256,bytes)` encoded with smart contract deployment it will be saved into the cache with those arguments from the encoded smart contract deployment function. Pasting another `execute` ABI encoded payload will be replaced with that smart contract deployment arguments.
- updated function `makeBytes32` to support all size bytes. Now it's called `makeBytes`.

Example of the issue. See the first log with `props.data` - this is the pasted value.
Other logs have a new value that is immediately replaced the value pasted.

<img width="1797" alt="Screenshot 2024-06-13 at 17 27 58" src="https://github.com/lukso-network/universalprofile-test-dapp/assets/36865532/fccabee0-b611-4a40-9d99-b8323f6cd4a5">

