### PR TITLE
chore: logging the request that is about to be sent;

### DIFF
--- a/src/compositions/useWeb3Connection.ts
+++ b/src/compositions/useWeb3Connection.ts
@@ -144,7 +144,7 @@ const sendTransaction = (
 }
 
 const sendRequest = (request: any): Promise<any> => {
-  console.log("Sending request:", request)
+  console.log('Sending request:', request)
   if (provider.value) {
     return provider.value.request(request)
   }

--- a/src/compositions/useWeb3Connection.ts
+++ b/src/compositions/useWeb3Connection.ts
@@ -144,6 +144,7 @@ const sendTransaction = (
 }
 
 const sendRequest = (request: any): Promise<any> => {
+  console.log("Sending request:", request)
   if (provider.value) {
     return provider.value.request(request)
   }


### PR DESCRIPTION
Added logging of the request that's being sent to the extension.
One of the reasons is to get a quick sample of the payload that we can edit manually and trigger requests using `window.lukso.request`:
![Screenshot 2024-07-29 at 12 37 26](https://github.com/user-attachments/assets/eff1ba0f-8531-49aa-8d63-adef397e9b38)
