### PR TITLE
fix: ABI decoding should take place instead of random cache being returned

### DIFF
--- a/src/helpers/functionUtils.ts
+++ b/src/helpers/functionUtils.ts
@@ -114,7 +114,6 @@ export const decodeData = async (
             .replace(/^[^(]*\(|\)[^)]*$/g, '')
             .split(',')
           const args = eth.abi.decodeParameters(params, data.substring(8)) || {}
-          console.log('decodeData args/params', args, params)
           const encodeArgs = Array(params.length)
             .fill(null)
             .map((_val, index) => {
@@ -134,7 +133,6 @@ export const decodeData = async (
                   throw new Error('Invalid address value')
                 }
               }
-              console.log('value at', index, args[`${index}`])
               return args[`${index}`] ?? '0x'
             })
           const newData =


### PR DESCRIPTION
The issue: pasting ABI of encoded function may read and show invalid arguments in the UI.
The reason: last saved value stored in `signature-cache2`, which includes all decoded values of the last input, is returned if it matches the function selector of the given ABI.

Instead we should only take function signature from the cache if anything is found and then decode given ABI encoded function call.

Bug:

https://github.com/user-attachments/assets/f8a40b18-ad2e-45a7-bd12-80c8f6b4ecc8

Bug solved:

https://github.com/user-attachments/assets/a9760ecb-9dbb-427f-b969-76817dcda479

